### PR TITLE
Added language type - who doesn't like colors?

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ At the moment only possible to install with packer(not rigorly tested) and with 
 
 ### Packer
 
-```
+```lua
 use {
     'MrSloth-dev/42-NorminetteNvim',
     requires = {'nvim-lua/plenary.nvim'},
@@ -19,7 +19,7 @@ use {
 ```
 ### Lazy.nvim
 
-```
+```lua
 {
 	"MrSloth-dev/42-NorminetteNvim",
 	dependencies = { "nvim-lua/plenary.nvim" },


### PR DESCRIPTION
Added a simple language type specification for Markdown format allowing the proper highlight of the colors according with the language written inside the scope, making the code more readable.